### PR TITLE
Add infniteLoop & Rename rewindLoop

### DIFF
--- a/doc-components/Api.js
+++ b/doc-components/Api.js
@@ -118,6 +118,13 @@ const props = {
     description: 'Number of slides to show at once',
     defaultValue: {value: '1', computed: false}
   },
+  infiniteLoop: {
+    type: {name: 'bool'},
+    required: false,
+    description:
+      'Determine if the slider will be infinite, by rewind. That means, that means when it arrives to the last slide, and the user clicks on next it does a rewind to the first slide. And when the slider is on the first slide, and the user clicks on previous, it does a forward to the last slide.',
+    defaultValue: {value: 'true', computed: false}
+  },
   sanitize: {
     type: {name: 'bool'},
     required: false,

--- a/doc-components/Api.js
+++ b/doc-components/Api.js
@@ -118,7 +118,7 @@ const props = {
     description: 'Number of slides to show at once',
     defaultValue: {value: '1', computed: false}
   },
-  infiniteLoop: {
+  rewindLoop: {
     type: {name: 'bool'},
     required: false,
     description:

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -9,7 +9,7 @@ import Dots from '../doc-components/Dots'
 import Number from '../doc-components/Number'
 import {CustomArrowLeft, CustomArrowRight} from '../doc-components/CustomArrows'
 
-<ReactSlidy>
+<ReactSlidy itemsToPreload={4} numOfSlides={3}>
   <img src="/1.jpg" />
   <img src="/2.jpg" />
   <img src="/3.jpg" />

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -9,7 +9,7 @@ import Dots from '../doc-components/Dots'
 import Number from '../doc-components/Number'
 import {CustomArrowLeft, CustomArrowRight} from '../doc-components/CustomArrows'
 
-<ReactSlidy itemsToPreload={4} numOfSlides={3}>
+<ReactSlidy>
   <img src="/1.jpg" />
   <img src="/2.jpg" />
   <img src="/3.jpg" />
@@ -182,7 +182,7 @@ return (
 
 ### Using Infinite Loop
 
-You could make your slider infinite. That meand when it arrive to the last slide, and the user clicks on next it starts again. And when the slider is on the first slide, and the user clicks on previous, it goes to the last slide.
+You could make your slider infinite. That means when it arrives to the last slide, and the user clicks on next it starts again. And when the slider is on the first slide, and the user clicks on previous, it goes to the last slide.
 
 #### Simple example with 5 slides in total
 
@@ -196,6 +196,30 @@ You could make your slider infinite. That meand when it arrive to the last slide
 
 ```js showButton
 <ReactSlidy infiniteLoop>
+  <Number num={1} />
+  <Number num={2} />
+  <Number num={3} />
+  <Number num={4} />
+  <Number num={5} />
+</ReactSlidy>
+```
+
+### Using Rewind Loop
+
+You could make your slider infinite, by rewind. That means when it arrives to the last slide, and the user clicks on next it does a rewind to the first slide. And when the slider is on the first slide, and the user clicks on previous, it does a forward to the last slide.
+
+#### Simple example with 5 slides in total
+
+<ReactSlidy rewindLoop>
+  <Number num={1} />
+  <Number num={2} />
+  <Number num={3} />
+  <Number num={4} />
+  <Number num={5} />
+</ReactSlidy>
+
+```js showButton
+<ReactSlidy rewindLoop>
   <Number num={1} />
   <Number num={2} />
   <Number num={3} />

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ const ReactSlidy = ({
   },
   keyboardNavigation = false,
   numOfSlides = 1,
+  rewindLoop = false,
   sanitize = true,
   slide = 0,
   slideSpeed = 500,
@@ -99,10 +100,11 @@ const ReactSlidy = ({
     doBeforeSlide,
     ease,
     infiniteLoop,
-    initialSlide,
+    initialSlide: infiniteLoop ? initialSlide + 1 : initialSlide,
     itemsToPreload,
     keyboardNavigation,
     numOfSlides,
+    rewindLoop,
     showArrows,
     slide,
     slideSpeed
@@ -160,6 +162,8 @@ ReactSlidy.propTypes = {
   }),
   /** Number of slides to show at once */
   numOfSlides: PropTypes.number,
+  /** Indicates if the slider will start with the first slide once it ends, doing it rewind */
+  rewindLoop: PropTypes.bool,
   /** Determine if we want to sanitize the slides or take numberOfSlider directly */
   sanitize: PropTypes.bool,
   /** Change dynamically the slide number, perfect to use with dots */

--- a/src/react-slidy-slider.js
+++ b/src/react-slidy-slider.js
@@ -105,11 +105,14 @@ export default function ReactSlidySlider({
         items: items.length,
         onNext: nextIndex => {
           setIndex(nextIndex)
-          nextIndex > maxIndex && setMaxIndex(nextIndex)
+          setMaxIndex(currentIndex =>
+            nextIndex > currentIndex ? nextIndex : currentIndex
+          )
           return nextIndex
         },
         onPrev: nextIndex => {
           setIndex(nextIndex)
+          if (infiniteLoop && nextIndex === 0) setMaxIndex(items.length + 1)
           return nextIndex
         }
       })

--- a/src/react-slidy-slider.js
+++ b/src/react-slidy-slider.js
@@ -11,11 +11,20 @@ function convertToArrayFrom(children) {
 function getItemsToRender({
   index,
   maxIndex,
-  items,
+  items: originalItems,
   itemsToPreload,
-  numOfSlides
+  numOfSlides,
+  infiniteLoop
 }) {
   const preload = Math.max(itemsToPreload, numOfSlides)
+  // If the slider is infinite, is needed clone the first and the last element
+  const items = infiniteLoop
+    ? [
+        originalItems[originalItems.length - 1],
+        ...originalItems,
+        originalItems[0]
+      ]
+    : originalItems
   if (index >= items.length - numOfSlides) {
     const addNewItems =
       items.length > numOfSlides ? items.slice(0, numOfSlides - 1) : []
@@ -54,6 +63,7 @@ export default function ReactSlidySlider({
   itemsToPreload,
   keyboardNavigation,
   numOfSlides,
+  rewindLoop,
   showArrows,
   slide,
   slideSpeed
@@ -70,6 +80,7 @@ export default function ReactSlidySlider({
   const slidesDOMEl = useRef(null)
 
   const items = convertToArrayFrom(children)
+  const isArrowsForced = infiniteLoop || rewindLoop
 
   useEffect(
     function() {
@@ -87,6 +98,7 @@ export default function ReactSlidySlider({
         doBeforeSlide,
         numOfSlides,
         slideSpeed,
+        rewindLoop,
         infiniteLoop,
         slidesDOMEl: slidesDOMEl.current,
         initialSlide: index,
@@ -132,14 +144,15 @@ export default function ReactSlidySlider({
     maxIndex,
     items,
     itemsToPreload,
-    numOfSlides
+    numOfSlides,
+    infiniteLoop
   })
 
   const handlePrev = e => slidyInstance.prev(e)
   const handleNext = e => items.length > numOfSlides && slidyInstance.next(e)
 
   const renderLeftArrow = () => {
-    const disabled = index === 0 && !infiniteLoop
+    const disabled = index === 0 && !isArrowsForced
     const props = {disabled, onClick: handlePrev}
     const leftArrowClasses = `${classNameBase}-arrow ${classNameBase}-arrowLeft`
     if (ArrowLeft) return <ArrowLeft {...props} className={leftArrowClasses} />
@@ -156,7 +169,7 @@ export default function ReactSlidySlider({
   const renderRightArrow = () => {
     const disabled =
       (items.length <= numOfSlides || index === items.length - 1) &&
-      !infiniteLoop
+      !isArrowsForced
     const props = {disabled, onClick: handleNext}
     const rightArrowClasses = `${classNameBase}-arrow ${classNameBase}-arrowRight`
     if (ArrowRight)

--- a/test/slidy.spec.js
+++ b/test/slidy.spec.js
@@ -1,4 +1,4 @@
-const {clampNumber, infiniteIndex, translate} = require('../src/slidy')
+const {clampNumber, rewindIndex, translate} = require('../src/slidy')
 
 describe('clampNumber', () => {
   test('when a number that is less than min value is provided then the min value is returned', () => {
@@ -21,7 +21,7 @@ describe('clampNumber', () => {
   })
 })
 
-describe('infiniteIndex', () => {
+describe('rewindIndex', () => {
   test('when a number that is less than 0 is provided then the end value - 1 is returned', () => {
     const when = [
       {value: -1, endValue: 4, expected: 3},
@@ -29,12 +29,12 @@ describe('infiniteIndex', () => {
     ]
 
     when.forEach(({value, endValue, expected}) => {
-      expect(infiniteIndex(value, endValue)).toBe(expected)
+      expect(rewindIndex(value, endValue)).toBe(expected)
     })
   })
 
   test('when a number that is greater than end value is provided then 0 is returned', () => {
-    expect(infiniteIndex(12, 8)).toBe(0)
+    expect(rewindIndex(12, 8)).toBe(0)
   })
 
   test('when a number that is between 0 and the end value is provided then the same value is returned', () => {
@@ -45,7 +45,7 @@ describe('infiniteIndex', () => {
     ]
 
     when.forEach(({value, endValue, expected}) => {
-      expect(infiniteIndex(value, endValue)).toBe(expected)
+      expect(rewindIndex(value, endValue)).toBe(expected)
     })
   })
 })


### PR DESCRIPTION
I've renamed the previous infniteLoop to rewindLoop

And implemented a real infniteLoop (only desktop), the approach is: clone the first image and add it at the end of the array, and clone the last image and add it at the beginning of the array. So in the case that the slide is in the cycle, and goes from the first one to the last one, is going to the cloned ones. When the animation is done, the  slider goes to the original one.

Pros: We have infinite loop :D
Contras: We clone 2 images, so it isn't the best, but it's only n + 2 images to render