### PR TITLE
Do not include null in items to render

### DIFF
--- a/src/react-slidy-slider.js
+++ b/src/react-slidy-slider.js
@@ -69,7 +69,7 @@ export default function ReactSlidySlider({
   const sliderContainerDOMEl = useRef(null)
   const slidesDOMEl = useRef(null)
 
-  const items = convertToArrayFrom(children)
+  const items = convertToArrayFrom(children).filter(child => child !== null);
 
   useEffect(
     function() {


### PR DESCRIPTION
Hello!

I noticed that children which are null, are included in the items to render (I'm not sure if this was done intentionally).

For my use case, this caused empty slides to be rendered sometimes, because I was conditionally rendering a component within `<ReactSlidy/>` like:

```
{component.enabled ? <Component/> : null}
```


So here is a PR, in case it makes sense for you too. Thank you for your work :)